### PR TITLE
Bugfix/plurals upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-xgettext-handlebars",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Gulp plugin to extract translatable strings from Handlebars templates",
   "author": "Gabe Gorelick",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-util": "^3.0.7",
     "object-assign": "^4.0.1",
     "through2": "^2.0.1",
-    "xgettext-handlebars": "0.0.5"
+    "xgettext-handlebars": "^0.0.6"
   },
   "devDependencies": {
     "jscs": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "gettext-catalog": "0.0.3",
-    "gulp-util": "^3.0.4",
-    "object-assign": "^3.0.0",
-    "through2": "^2.0.0",
+    "gettext-catalog": "^0.0.4",
+    "gulp-util": "^3.0.7",
+    "object-assign": "^4.0.1",
+    "through2": "^2.0.1",
     "xgettext-handlebars": "0.0.5"
   },
   "devDependencies": {
-    "jscs": "^1.12.0",
-    "jshint": "^2.6.3",
-    "mocha": "^2.2.1",
-    "pofile": "^0.2.12",
-    "should": "^7.0.2"
+    "jscs": "^2.11.0",
+    "jshint": "^2.9.1",
+    "mocha": "^2.4.5",
+    "pofile": "^1.0.2",
+    "should": "^8.2.2"
   },
   "scripts": {
     "test": "jscs *.js test/*.js && jshint *.js test/*.js && mocha"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-util": "^3.0.7",
     "object-assign": "^4.0.1",
     "through2": "^2.0.1",
-    "xgettext-handlebars": "^0.0.6"
+    "xgettext-handlebars": "https://github.com/jkalina/xgettext-handlebars.git#bugfix/plurals"
   },
   "devDependencies": {
     "jscs": "^2.11.0",


### PR DESCRIPTION
applies dependency to fixed version of gettext-catalog (0.0.4)
0.0.3 didn't extract plurals in correct way
